### PR TITLE
Fix type errors and remove unused interface

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -171,7 +171,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
           console.log('ElevenLabs API response status:', response.status);
           if (response.ok) {
-            const data = await response.json();
+            const data: any = await response.json();
             console.log('ElevenLabs API response data:', JSON.stringify(data).slice(0, 200) + '...');
             elevenLabsVoices = data.voices?.map((voice: any) => ({
               id: voice.voice_id,
@@ -315,7 +315,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       // Parse CSV file
       await new Promise<void>((resolve, reject) => {
-        fs.createReadStream(req.file.path)
+        fs.createReadStream(req.file!.path)
           .pipe(csv())
           .on('data', (row) => {
             // Validate required columns
@@ -422,7 +422,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           await storage.updateCallLog(callLog.id, {
             status: "failed",
           });
-          res.status(500).json({ error: `Failed to make call via Twilio: ${error.message}` });
+          const msg = error instanceof Error ? error.message : String(error);
+          res.status(500).json({ error: `Failed to make call via Twilio: ${msg}` });
         }
       } else {
         // Return error if credentials are missing
@@ -555,8 +556,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
           const campaign = await storage.getCampaign(callLog.campaignId);
           if (campaign) {
             await storage.updateCampaign(callLog.campaignId, {
-              completedCalls: campaign.completedCalls + 1,
-              successfulCalls: campaign.successfulCalls + 1,
+              completedCalls: (campaign.completedCalls || 0) + 1,
+              successfulCalls: (campaign.successfulCalls || 0) + 1,
             });
           }
         }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -73,13 +73,17 @@ export class MemStorage implements IStorage {
         description: "Professional Female",
         isCloned: false,
         sampleUrl: null,
+        settings: null,
+        category: null,
       },
       {
-        id: "voice_2", 
+        id: "voice_2",
         name: "Michael",
         description: "Friendly Male",
         isCloned: false,
         sampleUrl: null,
+        settings: null,
+        category: null,
       },
       {
         id: "voice_3",
@@ -87,7 +91,9 @@ export class MemStorage implements IStorage {
         description: "Warm Female",
         isCloned: false,
         sampleUrl: null,
-      }
+        settings: null,
+        category: null,
+      },
     ];
 
     defaultVoices.forEach(voice => this.voices.set(voice.id, voice));
@@ -99,6 +105,8 @@ export class MemStorage implements IStorage {
     const newCampaign: Campaign = {
       ...campaign,
       id,
+      status: campaign.status ?? "draft",
+      selectedVoiceId: campaign.selectedVoiceId ?? null,
       totalLeads: 0,
       completedCalls: 0,
       successfulCalls: 0,
@@ -168,8 +176,17 @@ export class MemStorage implements IStorage {
 
   // Voice operations
   async createVoice(voice: InsertVoice): Promise<Voice> {
-    this.voices.set(voice.id, voice);
-    return voice;
+    const newVoice: Voice = {
+      id: voice.id,
+      name: voice.name,
+      description: voice.description ?? null,
+      isCloned: voice.isCloned ?? null,
+      sampleUrl: voice.sampleUrl ?? null,
+      settings: voice.settings ?? null,
+      category: voice.category ?? null,
+    };
+    this.voices.set(newVoice.id, newVoice);
+    return newVoice;
   }
 
   async getAllVoices(): Promise<Voice[]> {
@@ -208,8 +225,13 @@ export class MemStorage implements IStorage {
   async createCallLog(callLog: InsertCallLog): Promise<CallLog> {
     const id = this.callLogIdCounter++;
     const newCallLog: CallLog = {
-      ...callLog,
       id,
+      campaignId: callLog.campaignId ?? null,
+      leadId: callLog.leadId ?? null,
+      phoneNumber: callLog.phoneNumber,
+      status: callLog.status,
+      duration: callLog.duration ?? null,
+      twilioCallSid: callLog.twilioCallSid ?? null,
       createdAt: new Date(),
     };
     this.callLogs.set(id, newCallLog);

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -108,17 +108,7 @@ export const voiceCloneSchema = z.object({
 export type TestCallRequest = z.infer<typeof testCallSchema>;
 export type VoiceCloneRequest = z.infer<typeof voiceCloneSchema>;
 
-export interface Voice {
-  id: string;
-  name: string;
-  description: string;
-  isCloned: boolean;
-  sampleUrl?: string;
-  settings?: {
-    stability: number;
-    similarity_boost: number;
-    style: number;
-    use_speaker_boost: boolean;
-  };
-  category?: string;
-}
+// Deprecated: client-side typings are provided in `client/src/lib/api.ts`.
+// Keeping a duplicate `Voice` interface here caused a name clash with the
+// Drizzle generated `Voice` type above which broke `npm run check`. The
+// interface is no longer used and has been removed.


### PR DESCRIPTION
## Summary
- remove unused `Voice` interface that clashed with drizzle types
- fix strict type errors across server logic
- ensure default voice data contains optional fields
- provide defaults for campaign and call log creation
- type Vite server options properly

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684018c32594832c91bb1615230a5c04